### PR TITLE
update Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Bindings to connect @angular/router to @angular-redux/core
     imports: [
       RouterModule.forRoot(routes),
       NgReduxModule,
-      NgReduxRouterModule
+      NgReduxRouterModule.forRoot()
       // ...your imports
     ],
     // Other stuff..


### PR DESCRIPTION
According to https://github.com/angular-redux/router/pull/24, "NgReduxRouterModule now needs to be imported with .forRoot"

This threw me off for a whole day!  So, it should be included in the Readme.